### PR TITLE
adapt changes with clickhouse handler

### DIFF
--- a/charts/databend-query/templates/configmap.yaml
+++ b/charts/databend-query/templates/configmap.yaml
@@ -21,9 +21,6 @@ data:
       max_server_memory_usage = {{ .Values.config.query.maxServerMemoryUsage | default 0 }}
       max_memory_limit_enabled = {{ .Values.config.query.maxMemoryLimitEnabled | default false }}
 
-      clickhouse_http_handler_host = {{ .Values.config.query.clickhouseHttpHandlerHost | default "127.0.0.1" | quote }}
-      clickhouse_http_handler_port = {{ .Values.service.ports.clickhouse | default 8124 | int64}}
-
       {{- range .Values.config.query.users }}
       [[query.users]]
         name = {{ .name | quote }}

--- a/charts/databend-query/templates/configmap.yaml
+++ b/charts/databend-query/templates/configmap.yaml
@@ -21,6 +21,9 @@ data:
       max_server_memory_usage = {{ .Values.config.query.maxServerMemoryUsage | default 0 }}
       max_memory_limit_enabled = {{ .Values.config.query.maxMemoryLimitEnabled | default false }}
 
+      clickhouse_http_handler_host = {{ .Values.config.query.clickhouseHttpHandlerHost | default "127.0.0.1" | quote }}
+      clickhouse_http_handler_port = {{ .Values.service.ports.clickhouse | default 8124 | int64}}
+
       {{- range .Values.config.query.users }}
       [[query.users]]
         name = {{ .name | quote }}

--- a/charts/databend-query/templates/deployment.yaml
+++ b/charts/databend-query/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: mysql
               containerPort: 3307
             - name: clickhouse
-              containerPort: 9000
+              containerPort: 8124
             - name: http
               containerPort: 8000
           livenessProbe:

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -28,7 +28,7 @@ service:
   ports:
     mysql: 3307
     http: 8000
-    clickhouse: 9000
+    clickhouse: 8124
     metric: 7070
     admin: 8080
     flight: 9090
@@ -51,6 +51,8 @@ config:
 
     managementMode: false
     jwtKeyFile: ""
+
+    clickhouseHttpHandlerHost: "0.0.0.0"
 
     # NOTE: user `root` is already built-in, will be ignored if defined here
     users: []

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -52,8 +52,6 @@ config:
     managementMode: false
     jwtKeyFile: ""
 
-    clickhouseHttpHandlerHost: "0.0.0.0"
-
     # NOTE: user `root` is already built-in, will be ignored if defined here
     users: []
       # - name: databend


### PR DESCRIPTION
Description:
1. set default clickhouse port as 8124
2. add configmap params for clickhouse handler

PR Reason:

Databend Clickhouse TCP handler has been removed(https://github.com/datafuselabs/databend/pull/7012#issue-1329969463)

Accoding to the document(https://databend.rs/doc/deploy/query/query-config#clickhouse_http_handler_port).
The default port for clickhouse http handler is 8124.

I think helm charts should change the default clickhouse port to 8124.

I wish to discuss the following two issues:
1. Should I add a clickhouse-http parameter or just change the current default value？
2. The default clickhouse_http_handler_host is set to "127.0.0.1" so we cannot access this port directly through k8s service, I set the default value to "0.0.0.0" in the values.yaml, I'm wondering if this is reasonable.