### PR TITLE
fix(query): fix unknown field "volumeClaimTemplates" in podspec when value.cache.enabled is true

### DIFF
--- a/charts/databend-query/templates/statefulset.yaml
+++ b/charts/databend-query/templates/statefulset.yaml
@@ -114,17 +114,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "databend-query.fullname" .}}
-      {{- if .Values.cache.enabled }}
-      volumeClaimTemplates:
-      - metadata:
-          name: cache
-        spec:
-          accessModes: [ "ReadWriteOnce" ]
-          storageClassName: {{ .Values.cache.storageClass | quote }}
-          resources:
-            requests:
-              storage: {{ .Values.cache.maxBytes | quote }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -137,3 +126,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.cache.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: cache
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.cache.storageClass | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.cache.maxBytes | quote }}
+  {{- end }}


### PR DESCRIPTION
Hi, I got an error about `unknown field "volumeclaimtemplates" in io.k8s.api.core.v1.podspec` when the `value.cache.enables` is true.

I found a typo, the `volumeClaimTemplates` should belong to `StatefulSetSpec`, not `StatefulSetSpec.templateSpec` 

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulset-v1-apps