### PR TITLE
fix(query): clickhouse endpoints env variable name typo (#78)

### DIFF
--- a/charts/databend-query/templates/statefulset.yaml
+++ b/charts/databend-query/templates/statefulset.yaml
@@ -83,10 +83,10 @@ spec:
               value: 0.0.0.0
             - name: QUERY_MYSQL_HANDLER_PORT
               value: "3307"
-            - name: QUERY_CLICKHOUSE_HANDLER_HOST
+            - name: QUERY_CLICKHOUSE_HTTP_HANDLER_HOST
               value: 0.0.0.0
-            - name: QUERY_CLICKHOUSE_HANDLER_PORT
-              value: "9000"
+            - name: QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
+              value: "8124"
             - name: QUERY_HTTP_HANDLER_HOST
               value: 0.0.0.0
             - name: QUERY_HTTP_HANDLER_PORT


### PR DESCRIPTION
Fix #78 

This PR also change the `QUERY_CLICKHOUSE_HTTP_HANDLER_PORT` from `9000` to `8124`. It is changed in #68, but the env variable name has a typo, it never take into effect. 

I think this is just temporary fix. PR #77 use the user defined ports for the statefulSet, but the statefulSet template file has its own env variables defined. 

Those two sets of ports can be easily unsynced as shown in #68. 

This should be documented in `values.yaml` for now, else the user defined ports has no use.

I think those ports should be listed as separate and dedicate yaml values, and then used for env variables and `statefulSet` and `service`. User shouldn't define the port name, and it better not `ranged` in template.

 
