### PR TITLE
feat(query): support workload type deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ concurrency:
 
 jobs:
   k3d:
+    strategy:
+      matrix:
+        workload:
+          - StatefulSet
+          - Deployment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +64,7 @@ jobs:
             --set bootstrap=true \
             --set replicaCount=3 \
             --set persistence.size=1Gi \
-            --wait
+            --wait --timeout 2m0s
           kubectl get pods -n databend-meta
 
       - name: Install MinIO
@@ -68,7 +73,7 @@ jobs:
           helm upgrade --install minio minio/minio \
             --namespace minio --create-namespace \
             --values tests/minio.yaml \
-            --wait
+            --wait --timeout 1m0s
 
       - name: Install Databend Query
         shell: bash
@@ -82,7 +87,8 @@ jobs:
           helm upgrade --install cluster1 . \
             --namespace tenant1 --create-namespace \
             --values ../../tests/query-with-minio.yaml \
-            --wait
+            --set workload=${{ matrix.workload }} \
+            --wait --timeout 1m0s
           kubectl get pods -n tenant1
 
       - name: Checking Cluster Status

--- a/charts/databend-meta/Chart.yaml
+++ b/charts/databend-meta/Chart.yaml
@@ -26,13 +26,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.279"
+appVersion: "v1.2.371"
 
 dependencies:
 - name: common

--- a/charts/databend-query/Chart.yaml
+++ b/charts/databend-query/Chart.yaml
@@ -25,13 +25,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.3
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.279"
+appVersion: "v1.2.371"
 
 dependencies:
 - name: common

--- a/charts/databend-query/templates/configmap.yaml
+++ b/charts/databend-query/templates/configmap.yaml
@@ -9,9 +9,6 @@ data:
   config.toml: |-
     # databend query config
     [query]
-      max_active_sessions = {{ .Values.config.query.maxActiveSessions | default 1024 }}
-      wait_timeout_mills = {{ .Values.config.query.waitTimeoutMills | default 5000 }}
-
       tenant_id = {{ .Values.config.query.tenantId | default .Release.Name | quote }}
       cluster_id = {{ .Values.config.query.clusterId | quote }}
 
@@ -83,7 +80,7 @@ data:
         {{- end }}
       {{- end }}
 
-    {{- if .Values.cache.enabled }}
+    {{- if and .Values.cache.enabled (eq (lower .Values.workload) "statefulset") }}
     [cache]
       data_cache_storage = "disk"
       [cache.disk]

--- a/charts/databend-query/templates/deployment.yaml
+++ b/charts/databend-query/templates/deployment.yaml
@@ -1,15 +1,13 @@
-{{- if eq (lower .Values.workload) "statefulset" }}
+{{- if eq (lower .Values.workload) "deployment" }}
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "databend-query.fullname" . }}
   labels:
     {{- include "databend-query.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "databend-query.fullname" . }}
   replicas: {{ .Values.replicaCount }}
-  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "databend-query.selectorLabels" . | nindent 6 }}
@@ -104,10 +102,6 @@ spec:
             - name: config
               # Note: subPath volume mount will not receive ConfigMap update.
               mountPath: /etc/databend-query
-            {{- if .Values.cache.enabled }}
-            - name: cache
-              mountPath: {{ .Values.cache.path | default "/var/lib/databend/cache" | quote }}
-            {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -127,15 +121,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.cache.enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: cache
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.cache.storageClass | quote }}
-      resources:
-        requests:
-          storage: {{ .Values.cache.maxBytes | quote }}
-  {{- end }}
 {{- end }}

--- a/charts/databend-query/templates/service.yaml
+++ b/charts/databend-query/templates/service.yaml
@@ -19,4 +19,6 @@ spec:
     {{- end }}
   selector:
     {{- include "databend-query.selectorLabels" . | nindent 4 }}
+    {{- if eq (lower .Values.workload) "statefulset" }}
     statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
+    {{- end }}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+# Could be StatefulSet or Deployment
+workload: StatefulSet
+
 image:
   repository: datafuselabs/databend-query
   pullPolicy: IfNotPresent
@@ -50,14 +53,14 @@ serviceMonitor:
 config:
   # [query]
   query:
-    maxActiveSessions: 256
-    waitTimeoutMills: 5000
-
     tenantId: ""
     clusterId: default
 
     managementMode: false
     jwtKeyFile: ""
+
+    extra:
+      max_active_sessions: 256
 
     # NOTE: user `root` is already built-in, will be ignored if defined here
     users: []
@@ -66,8 +69,6 @@ config:
       #   # sha1sum: echo -n "password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum
       #   authType: double_sha1_password
       #   authString: 3081f32caef285c232d066033c89a78d88a6d8a5  # databend
-
-    extra: {}
 
   # [log]
   log:
@@ -115,6 +116,7 @@ config:
       access_key_id: ""
       access_key_secret: ""
 
+# NOTE: only for StatefulSet
 cache:
   enabled: false
   path: "/var/lib/databend/cache"

--- a/examples/query-cluster-as-deployment.yaml
+++ b/examples/query-cluster-as-deployment.yaml
@@ -1,0 +1,2 @@
+replicaCount: 3
+workload: Deployment


### PR DESCRIPTION
## Description:
This pull request introduces support for workload type deployment in the query component.

## Changes:

- Added support for workload type deployment in the .github/workflows/ci.yml file.
- Modified configurations in charts/databend-meta/Chart.yaml and charts/databend-query/Chart.yaml.
- Updated configurations in charts/databend-query/templates/configmap.yaml.
- Added a new template file charts/databend-query/templates/deployment.yaml for deployment workload.
- Modified charts/databend-query/templates/service.yaml and charts/databend-query/templates/statefulset.yaml to conditionally set labels based on workload type.
- Updated charts/databend-query/values.yaml to include workload field, allowing users to specify StatefulSet or Deployment as the workload type.
- Added an example file examples/query-cluster-as-deployment.yaml demonstrating usage of Deployment as the workload type.

## Impact:

- Users can now deploy the query component using Deployment as the workload type.
- Provides flexibility in deployment strategies based on workload requirements.
- Ensures compatibility with StatefulSet and Deployment workloads.