### PR TITLE
Auto generate meta endpoints feature

### DIFF
--- a/charts/databend-query/Chart.yaml
+++ b/charts/databend-query/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/databend-query/templates/configmap.yaml
+++ b/charts/databend-query/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
 
     [meta]
       {{- if .Values.config.meta.generateEndpoints }}
-      endpoints = [{{ range $i := (untilStep 0 (int $.Values.config.meta.metaReplicas) 1) }}"{{ $.Release.Name }}-databend-meta-{{ $i }}.{{ $.Release.Name }}-databend-meta.{{ $.Values.config.meta.metaNamespace | default $.Release.Namespace }}.svc.cluster.local:{{ $.Values.config.meta.metaPort }}",{{ end }}]
+      endpoints = [{{ range $i := (untilStep 0 (int $.Values.config.meta.replicas) 1) }}"{{ $.Release.Name }}-databend-meta-{{ $i }}.{{ $.Release.Name }}-databend-meta.{{ $.Values.config.meta.namespace | default $.Release.Namespace }}.svc.cluster.local:{{ $.Values.config.meta.port }}",{{ end }}]
       {{- else }}
       endpoints = [{{ range .Values.config.meta.endpoints }}{{ . | quote }},{{ end }}]
       {{- end }}

--- a/charts/databend-query/templates/configmap.yaml
+++ b/charts/databend-query/templates/configmap.yaml
@@ -47,7 +47,11 @@ data:
         level = {{ .Values.config.log.stderr.level | default "WARN" | quote }}
 
     [meta]
+      {{- if .Values.config.meta.generateEndpoints }}
+      endpoints = [{{ range $i := (untilStep 0 (int $.Values.config.meta.metaReplicas) 1) }}"{{ $.Release.Name }}-databend-meta-{{ $i }}.{{ $.Release.Name }}-databend-meta.{{ $.Values.config.meta.metaNamespace | default $.Release.Namespace }}.svc.cluster.local:{{ $.Values.config.meta.metaPort }}",{{ end }}]
+      {{- else }}
       endpoints = [{{ range .Values.config.meta.endpoints }}{{ . | quote }},{{ end }}]
+      {{- end }}
       username = {{ .Values.config.meta.username | quote }}
       password = {{ .Values.config.meta.password | quote }}
       client_timeout_in_second = {{ .Values.config.meta.clientTimeoutInSecond | default 60 }}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -93,6 +93,14 @@ config:
 
   # [meta]
   meta:
+    # If databend-meta is hosted in the same cluster as databend-data, you can enable this to generate endpoints in a K8s native way.
+    generateEndpoints: false
+    # Databend-meta replica count
+    metaReplicas: 3
+    # Databend-meta port if you need to change it
+    metaPort: 9191
+    # If databend-meta is located in the same cluster, but a different namespace, specify it here
+    metaNamespace: ""
     # Set endpoints to use remote meta service
     endpoints:
       # <podName>.<serviceName>.<namespace>.svc.cluster.local:9191

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -96,11 +96,11 @@ config:
     # If databend-meta is hosted in the same cluster as databend-data, you can enable this to generate endpoints in a K8s native way.
     generateEndpoints: false
     # Databend-meta replica count
-    metaReplicas: 3
+    replicas: 3
     # Databend-meta port if you need to change it
-    metaPort: 9191
+    port: 9191
     # If databend-meta is located in the same cluster, but a different namespace, specify it here
-    metaNamespace: ""
+    namespace: ""
     # Set endpoints to use remote meta service
     endpoints:
       # <podName>.<serviceName>.<namespace>.svc.cluster.local:9191


### PR DESCRIPTION
I've added the ability to generate endpoints based on some template variables.

This is especially helpful in multi tenant deployments where databend-meta is not shared between query deployments.

.Values.config.meta.generateEndpoints defaults to false, and as a result, the behavior of this chart should not change for anyone who does not modify this field.