### PR TITLE
feat: allow enable load blance queries

### DIFF
--- a/charts/databend-query/templates/ingress.yaml
+++ b/charts/databend-query/templates/ingress.yaml
@@ -6,6 +6,9 @@
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
+{{- if .Values.ingress.loadBalanceByRouteHint }}
+  {{- $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/upstream-hash-by" "$http_x_databend_route_hint" }}
+{{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/databend-query/templates/ingress.yaml
+++ b/charts/databend-query/templates/ingress.yaml
@@ -6,7 +6,7 @@
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if .Values.ingress.loadBalanceByRouteHint }}
+{{- if .Values.ingress.loadBalanceQueries }}
   {{- $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/upstream-hash-by" "$http_x_databend_route_hint" }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/databend-query/templates/ingress.yaml
+++ b/charts/databend-query/templates/ingress.yaml
@@ -6,7 +6,7 @@
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if .Values.ingress.loadBalanceQueries }}
+{{- if .Values.enableLoadBalance }}
   {{- $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/upstream-hash-by" "$http_x_databend_route_hint" }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/databend-query/templates/service.yaml
+++ b/charts/databend-query/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
     {{- end }}
   selector:
     {{- include "databend-query.selectorLabels" . | nindent 4 }}
-    {{- if eq (lower .Values.workload) "statefulset" }}
+    {{- if and (eq .Values.workload "statefulset") (not .Values.enableLoadBalance) }}
     statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
     {{- end }}
   {{- with .Values.service.sessionAffinity }}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -7,6 +7,10 @@ replicaCount: 1
 # Could be StatefulSet or Deployment
 workload: StatefulSet
 
+# By default, the queries are routed to the first node in the StatefulSet, and this node is considered 
+# as the coordinator. If you want to enable load balance queries across nodes, set this to true.
+enableLoadBalance: false
+
 image:
   repository: datafuselabs/databend-query
   pullPolicy: IfNotPresent
@@ -150,7 +154,6 @@ cache:
 
 ingress:
   enabled: false
-  loadBalanceQueries: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -150,6 +150,7 @@ cache:
 
 ingress:
   enabled: false
+  loadBalanceQueries: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
if load balance queries is enabled, ingress will load balance the queries by the hash of `X-databend-route-hint`.

this requires the driver client versions which have x-databend-route-hint supported.