### PR TITLE
Adds Topology Spread Constraints to Databend Meta Pods

### DIFF
--- a/charts/databend-query/templates/statefulset.yaml
+++ b/charts/databend-query/templates/statefulset.yaml
@@ -127,6 +127,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}  
   {{- if .Values.cache.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -202,6 +202,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 sidecars: []
 # Attach additional containers to the pod
 # - name: your-image-name


### PR DESCRIPTION
Just adds optional topology spread constraints to Databend meta pods.

This is useful if you want to force a statefulset to schedule across two different types of nodes or other k8s node labels.