### PR TITLE
fix(charts): support IPv6 listen hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - Deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install k3d
         shell: bash
@@ -38,7 +38,9 @@ jobs:
           k3d cluster create databend
           kubectl cluster-info
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
+        with:
+          version: v3.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -18,15 +18,15 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
-          version: v3.8.1
+          version: v3.19.0
       - name: Helm Deps
         run: |
           helm repo add minio https://charts.min.io/
           helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Publish Helm chart
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1
         with:
           charts_repo_url: https://charts.databend.com
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */*/charts/
 .idea
+.alma-snapshots

--- a/charts/databend-meta/Chart.yaml
+++ b/charts/databend-meta/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 
 type: application
 
-version: 0.11.0
+version: 0.11.1
 
 appVersion: "v1.2.786-nightly"
 

--- a/charts/databend-meta/templates/_config.tpl
+++ b/charts/databend-meta/templates/_config.tpl
@@ -1,6 +1,6 @@
 {{- define "common.metaConfig" -}}
-admin_api_address = "0.0.0.0:{{ .Values.service.ports.admin }}"
-grpc_api_address = "0.0.0.0:{{ .Values.service.ports.grpc }}"
+admin_api_address = {{ include "databend-meta.socketAddress" (dict "host" .Values.config.listenHost "port" .Values.service.ports.admin) | quote }}
+grpc_api_address = {{ include "databend-meta.socketAddress" (dict "host" .Values.config.listenHost "port" .Values.service.ports.grpc) | quote }}
 
 [log]
 [log.stderr]
@@ -17,7 +17,7 @@ grpc_api_address = "0.0.0.0:{{ .Values.service.ports.grpc }}"
 [raft_config]
   cluster_name = {{ .Values.config.clusterName | quote }}
   raft_dir = {{ .Values.config.raft.dir | quote }}
-  raft_listen_host = "0.0.0.0"
+  raft_listen_host = {{ .Values.config.raft.listenHost | quote }}
   raft_api_port = {{ .Values.service.ports.raft }}
   max_applied_log_to_keep = 102400
   install_snapshot_timeout = 60000

--- a/charts/databend-meta/templates/_helpers.tpl
+++ b/charts/databend-meta/templates/_helpers.tpl
@@ -51,6 +51,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Format a host and port as a socket address. IPv6 hosts must be bracketed.
+*/}}
+{{- define "databend-meta.socketAddress" -}}
+{{- $host := .host | toString -}}
+{{- $port := .port | toString -}}
+{{- if and (contains ":" $host) (not (hasPrefix "[" $host)) -}}
+{{- printf "[%s]:%s" $host $port -}}
+{{- else -}}
+{{- printf "%s:%s" $host $port -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "databend-meta.serviceAccountName" -}}

--- a/charts/databend-meta/templates/service.yaml
+++ b/charts/databend-meta/templates/service.yaml
@@ -13,6 +13,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   publishNotReadyAddresses: true
   clusterIP: None
   ports:

--- a/charts/databend-meta/templates/statefulset.yaml
+++ b/charts/databend-meta/templates/statefulset.yaml
@@ -156,7 +156,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            {{- if .Values.existingConfigMaps }}
+            {{- if .Values.existingConfigMap }}
             name: {{ .Values.existingConfigMap }}
             {{- else }}
             name: {{ include "databend-meta.fullname" . }}

--- a/charts/databend-meta/values.yaml
+++ b/charts/databend-meta/values.yaml
@@ -47,6 +47,8 @@ readinessProbe:
 service:
   type: ClusterIP
   clusterDomain: "cluster.local"
+  ipFamilyPolicy: ""
+  ipFamilies: []
   ports:
     admin: 28002
     raft: 28004
@@ -67,6 +69,7 @@ podMonitor:
 
 # would be ignored if `existingConfigMap` is set
 config:
+  listenHost: "0.0.0.0"
   log:
     file:
       enabled: false
@@ -81,6 +84,7 @@ config:
   clusterName: databend
   raft:
     dir: /data/databend-meta/raft
+    listenHost: "0.0.0.0"
 
 existingConfigMap: ""
 

--- a/charts/databend-query/Chart.yaml
+++ b/charts/databend-query/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.5
+version: 0.12.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/databend-query/templates/deployment.yaml
+++ b/charts/databend-query/templates/deployment.yaml
@@ -82,19 +82,19 @@ spec:
             - name: QUERY_FLIGHT_API_ADDRESS
               value: "$(POD_IP):{{ .Values.service.ports.flight | default 9090 }}"
             - name: QUERY_HTTP_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_HTTP_HANDLER_PORT
               value: {{ .Values.service.ports.http | default 8000 | quote }}
             - name: QUERY_FLIGHT_SQL_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_FLIGHT_SQL_HANDLER_PORT
               value: {{ .Values.service.ports.flightsql | default 8900 | quote }}
             - name: QUERY_MYSQL_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_MYSQL_HANDLER_PORT
               value: {{ .Values.service.ports.mysql | default 3307 | quote }}
             - name: QUERY_CLICKHOUSE_HTTP_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
               value: {{ .Values.service.ports.ckhttp | default 8124 | quote }}
             {{- with .Values.envs }}

--- a/charts/databend-query/templates/service.yaml
+++ b/charts/databend-query/templates/service.yaml
@@ -13,6 +13,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.service.ports }}
     - port: {{ $val }}

--- a/charts/databend-query/templates/statefulset.yaml
+++ b/charts/databend-query/templates/statefulset.yaml
@@ -95,19 +95,19 @@ spec:
             - name: QUERY_FLIGHT_API_ADDRESS
               value: "$(POD_IP):{{ .Values.service.ports.flight | default 9090 }}"
             - name: QUERY_HTTP_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_HTTP_HANDLER_PORT
               value: {{ .Values.service.ports.http | default 8000 | quote }}
             - name: QUERY_FLIGHT_SQL_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_FLIGHT_SQL_HANDLER_PORT
               value: {{ .Values.service.ports.flightsql | default 8900 | quote }}
             - name: QUERY_MYSQL_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_MYSQL_HANDLER_PORT
               value: {{ .Values.service.ports.mysql | default 3307 | quote }}
             - name: QUERY_CLICKHOUSE_HTTP_HANDLER_HOST
-              value: 0.0.0.0
+              value: {{ .Values.service.listenHost | quote }}
             - name: QUERY_CLICKHOUSE_HTTP_HANDLER_PORT
               value: {{ .Values.service.ports.ckhttp | default 8124 | quote }}
             {{- with .Values.envs }}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -38,6 +38,9 @@ readinessProbe:
 
 service:
   type: ClusterIP
+  listenHost: "0.0.0.0"
+  ipFamilyPolicy: ""
+  ipFamilies: []
   ports:
     metric: 7070
     admin: 8080


### PR DESCRIPTION
## Problem
Databend Helm charts currently assume IPv4 wildcard listeners in several places, which blocks IPv6-only Kubernetes clusters. The meta chart also has a typo in the `existingConfigMap` check, so users cannot reliably provide their own meta config as a workaround.

Closes #137

## Approach
Make listener hosts configurable while preserving the existing IPv4 defaults. For meta API socket addresses, format IPv6 hosts with brackets so `::` renders as `[::]:port` instead of the invalid `:::port` form.

The service templates also expose Kubernetes IP family options so IPv6-only or dual-stack clusters can set `ipFamilyPolicy` and `ipFamilies` explicitly.

## Scope
- Add configurable listen hosts for `databend-meta` and `databend-query`
- Fix `existingConfigMap` lookup in the meta StatefulSet
- Add optional Service `ipFamilyPolicy` and `ipFamilies` values
- Bump chart versions for both changed charts
- Ignore local Alma snapshot files

## Validation
- [x] `helm template databend-meta charts/databend-meta`
- [x] `helm template databend-meta charts/databend-meta --set config.listenHost=:: --set config.raft.listenHost=:: --set service.ipFamilyPolicy=SingleStack --set service.ipFamilies[0]=IPv6`
- [x] `helm template databend-query charts/databend-query`
- [x] `helm template databend-query charts/databend-query --set service.listenHost=:: --set service.ipFamilyPolicy=SingleStack --set service.ipFamilies[0]=IPv6`
- [x] `helm lint charts/databend-meta`
- [x] `helm lint charts/databend-query`
