### PR TITLE
feat(charts): upgrade Databend to v1.2.881

### DIFF
--- a/charts/databend-meta/Chart.yaml
+++ b/charts/databend-meta/Chart.yaml
@@ -15,9 +15,9 @@ keywords:
 
 type: application
 
-version: 0.11.1
+version: 0.12.0
 
-appVersion: "v1.2.786-nightly"
+appVersion: "v1.2.881"
 
 dependencies:
 - name: common

--- a/charts/databend-query/Chart.yaml
+++ b/charts/databend-query/Chart.yaml
@@ -25,13 +25,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.6
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.786-nightly"
+appVersion: "v1.2.881"
 
 dependencies:
 - name: common


### PR DESCRIPTION
## Problem
The Databend Helm charts are still pointing at a nightly Databend build. The latest stable release should be used for the default meta and query images so new installs track a stable upstream version.

## Approach
Update both chart `appVersion` values to `v1.2.881`, the latest stable Databend release, and bump each chart minor version for the stable image upgrade.

## Scope
- Upgrade `databend-meta` appVersion from `v1.2.786-nightly` to `v1.2.881`
- Upgrade `databend-query` appVersion from `v1.2.786-nightly` to `v1.2.881`
- Bump `databend-meta` chart version from `0.11.1` to `0.12.0`
- Bump `databend-query` chart version from `0.12.6` to `0.13.0`

## Validation
- [x] `helm dependency build charts/databend-meta`
- [x] `helm dependency build charts/databend-query`
- [x] `helm lint charts/databend-meta`
- [x] `helm lint charts/databend-query`
- [x] `helm template databend-meta charts/databend-meta`
- [x] `helm template databend-query charts/databend-query`
